### PR TITLE
[OS-2728] adding logger via middleware - camunda library v1.0.0 

### DIFF
--- a/camunda/client.go
+++ b/camunda/client.go
@@ -15,7 +15,7 @@ type (
 	Client interface {
 		StartProcess(ctx context.Context, businessKey string, variables map[string]Variable) error
 		SendMessage(ctx context.Context, messageType string, businessKey string, updatedVariables map[string]Variable) error
-		Subscribe(topicName string, workerID string, handler TaskHandler, options ...func(*Subscription)) *Subscription
+		Subscribe(ctx context.Context, topicName string, workerID string, handler TaskHandler, options ...func(*Subscription)) *Subscription
 	}
 	BasicAuthCredentials struct {
 		User     string
@@ -77,7 +77,7 @@ func (c *client) SendMessage(ctx context.Context, messageType string, businessKe
 	return nil
 }
 
-func (c *client) Subscribe(topicName string, workerID string, handler TaskHandler, options ...func(*Subscription)) *Subscription {
+func (c *client) Subscribe(ctx context.Context, topicName string, workerID string, handler TaskHandler, options ...func(*Subscription)) *Subscription {
 	sub := newSubscription(c, topicName, workerID)
 	sub.addHandler(handler)
 
@@ -86,7 +86,7 @@ func (c *client) Subscribe(topicName string, workerID string, handler TaskHandle
 	}
 
 	// run async fetch loop
-	go sub.schedule()
+	go sub.schedule(ctx)
 
 	return sub
 }

--- a/camunda/client.go
+++ b/camunda/client.go
@@ -153,3 +153,4 @@ func (c *client) doPostRequest(ctx context.Context, params *bytes.Buffer, endpoi
 
 	return body, nil
 }
+

--- a/camunda/examples/task-subscription/main.go
+++ b/camunda/examples/task-subscription/main.go
@@ -37,7 +37,7 @@ func main() {
 	client := camunda.NewClient(url, processKey, http.Client{}, camunda.BasicAuthCredentials{})
 
 	handler := taskHandler{}
-	subscription := client.Subscribe(topic, workerID, &handler,
+	subscription := client.Subscribe(context.Background(), topic, workerID, &handler,
 		camunda.FetchInterval(time.Second*2),
 		camunda.MaxTasksFetch(10),
 		camunda.LockDuration(2000),
@@ -48,10 +48,10 @@ func main() {
 	subscription.Stop()
 }
 
-func (th *taskHandler) Handle(completeFunc camunda.TaskCompleteFunc, t camunda.Task) {
+func (th *taskHandler) Handle(ctx context.Context, completeFunc camunda.TaskCompleteFunc, t camunda.Task) {
 	log.Info().Msgf("Handling Task [%s] on topic [%s]", t.ID, t.TopicName)
 
-	err := completeFunc(context.Background(), t.ID)
+	err := completeFunc(ctx, t.ID)
 	if err != nil {
 		log.Err(err).Msgf("Failed to complete task [%s]", t.ID)
 	}

--- a/camunda/subscription.go
+++ b/camunda/subscription.go
@@ -76,12 +76,12 @@ func (s *Subscription) addHandler(handler TaskHandler) {
 
 // fetch connects to camunda and starts polling the external tasks
 // It will call each Handler if there is a new task on the topic
-func (s *Subscription) fetch(fal fetchAndLock) {
+func (s *Subscription) fetch(ctx context.Context, fal fetchAndLock) {
 	tasks, _ := s.client.fetchAndLock(&fal)
 	for _, task := range tasks {
 		for _, handler := range s.handlers {
 			task.BusinessKey = extractBusinessKey(task)
-			handler(s.complete, task)
+			handler(ctx, s.complete, task)
 		}
 	}
 }
@@ -94,7 +94,7 @@ func extractBusinessKey(task Task) string {
 	return value.Value.(string)
 }
 
-func (s *Subscription) schedule() {
+func (s *Subscription) schedule(ctx context.Context) {
 	atomic.AddInt32(&s.isRunning, 1)
 	lockParam := fetchAndLock{
 		WorkerID: s.workerID,
@@ -109,6 +109,10 @@ func (s *Subscription) schedule() {
 
 	for s.isRunning > 0 {
 		<-time.After(s.interval) // fetch every x seconds
-		go s.fetch(lockParam)
+		go s.fetch(ctx, lockParam)
 	}
+}
+
+func (h TaskHandlerFunc) Handle(ctx context.Context, completeFunc TaskCompleteFunc, t Task) {
+	h(ctx, completeFunc, t)
 }

--- a/camunda/types.go
+++ b/camunda/types.go
@@ -20,10 +20,10 @@ type (
 		Variables   map[string]Variable `json:"variables"`
 	}
 	TaskHandler interface {
-		Handle(completeFunc TaskCompleteFunc, t Task)
+		Handle(ctx context.Context, completeFunc TaskCompleteFunc, t Task)
 	}
 	TaskCompleteFunc func(ctx context.Context, taskID string) error
-	TaskHandlerFunc  func(completeFunc TaskCompleteFunc, t Task)
+	TaskHandlerFunc  func(ctx context.Context, completeFunc TaskCompleteFunc, t Task)
 )
 
 func NewStringVariable(varType string, value interface{}) Variable {


### PR DESCRIPTION
this is PR adds context to `Subscribe API` of camunda module

this PR is one of the two PRs of [this](https://blacklane.atlassian.net/jira/software/c/projects/OS/boards/182?modal=detail&selectedIssue=OS-2728) ticket

purpose of adding context is to inject logger using Middlewear. 
In future we can extend it to adding tracking number, etc.

As this a major change which is not backward compatible, we are changing the version number of the library