### PR TITLE
[OS-2728] adding logger via middleware - camunda library v1.0.0

### DIFF
--- a/camunda/examples/task-subscription/main.go
+++ b/camunda/examples/task-subscription/main.go
@@ -56,4 +56,3 @@ func (th *taskHandler) Handle(ctx context.Context, completeFunc camunda.TaskComp
 		log.Err(err).Msgf("Failed to complete task [%s]", t.ID)
 	}
 }
-

--- a/camunda/examples/task-subscription/main.go
+++ b/camunda/examples/task-subscription/main.go
@@ -48,7 +48,7 @@ func main() {
 	subscription.Stop()
 }
 
-func (th *taskHandler) Handle(completeFunc camunda.TaskCompleteFunc, t camunda.Task) {
+func (th *taskHandler) Handle(ctx context.Context, completeFunc camunda.TaskCompleteFunc, t camunda.Task) {
 	log.Info().Msgf("Handling Task [%s] on topic [%s]", t.ID, t.TopicName)
 
 	err := completeFunc(context.Background(), t.ID)

--- a/camunda/examples/task-subscription/main.go
+++ b/camunda/examples/task-subscription/main.go
@@ -56,3 +56,4 @@ func (th *taskHandler) Handle(ctx context.Context, completeFunc camunda.TaskComp
 		log.Err(err).Msgf("Failed to complete task [%s]", t.ID)
 	}
 }
+

--- a/camunda/subscription.go
+++ b/camunda/subscription.go
@@ -81,7 +81,7 @@ func (s *Subscription) fetch(fal fetchAndLock) {
 	for _, task := range tasks {
 		for _, handler := range s.handlers {
 			task.BusinessKey = extractBusinessKey(task)
-			handler(s.complete, task)
+			handler(context.Background(), s.complete, task)
 		}
 	}
 }

--- a/camunda/types.go
+++ b/camunda/types.go
@@ -20,11 +20,15 @@ type (
 		Variables   map[string]Variable `json:"variables"`
 	}
 	TaskHandler interface {
-		Handle(completeFunc TaskCompleteFunc, t Task)
+		Handle(ctx context.Context, completeFunc TaskCompleteFunc, t Task)
 	}
 	TaskCompleteFunc func(ctx context.Context, taskID string) error
-	TaskHandlerFunc  func(completeFunc TaskCompleteFunc, t Task)
+	TaskHandlerFunc  func(ctx context.Context, completeFunc TaskCompleteFunc, t Task)
 )
+
+func (h TaskHandlerFunc) Handle(ctx context.Context, completeFunc TaskCompleteFunc, t Task) {
+	h(ctx, completeFunc, t)
+}
 
 func NewStringVariable(varType string, value interface{}) Variable {
 	return Variable{


### PR DESCRIPTION
this is PR adds context to task handler of camunda module

this PR is one of the two PRs of this ticket

purpose of adding context is to inject logger using Middlewear.
In future we can extend it to adding tracking number, etc.

As this a major change which is not backward compatible, we are changing the version number of the library