### PR TITLE
logger: change no filter keys log message

### DIFF
--- a/logger/middleware/http.go
+++ b/logger/middleware/http.go
@@ -109,7 +109,7 @@ func HTTPRequestLogger(skipRoutes []string) func(http.Handler) http.Handler {
 func getKeys(ctx context.Context, log logger.Logger) []string {
 	keys, ok := ctx.Value(internal.FilterKeys).([]string)
 	if !ok {
-		log.Log().Msg("error getting filter keys from context")
+		log.Log().Msg("couldn't get filter keys from context")
 	}
 
 	if len(keys) == 0 {


### PR DESCRIPTION
It's my understanding that HTTP requests don't need to have an explicitly defined list of filter keys. Its absence is logged as an info message. I think using the word "error" in the log message is misleading.