### PR TITLE
otel: reuse http handler for each request

### DIFF
--- a/middleware/http_example_test.go
+++ b/middleware/http_example_test.go
@@ -53,6 +53,7 @@ func ExampleHTTP() {
 	//   "path": "/foo",
 	//   "request_id": "tracking_id_ExampleHTTP",
 	//   "timestamp": "2009-11-10T23:00:00.000Z",
+	//   "trace_id": "00000000000000000000000000000000",
 	//   "tracking_id": "tracking_id_ExampleHTTP",
 	//   "user_agent": "",
 	//   "verb": "GET"
@@ -115,6 +116,7 @@ func ExampleHTTP_onlyRequestIDHeader() {
 	//   "path": "/foo",
 	//   "request_id": "ExampleHTTP_onlyRequestIDHeader",
 	//   "timestamp": "2009-11-10T23:00:00.000Z",
+	//   "trace_id": "00000000000000000000000000000000",
 	//   "tracking_id": "ExampleHTTP_onlyRequestIDHeader",
 	//   "user_agent": "",
 	//   "verb": "GET"
@@ -178,6 +180,7 @@ func ExampleHTTP_trackingIDAndRequestIDHeaders() {
 	//   "path": "/foo",
 	//   "request_id": "ExampleHTTP_trackingIDAndRequestIDHeaders",
 	//   "timestamp": "2009-11-10T23:00:00.000Z",
+	//   "trace_id": "00000000000000000000000000000000",
 	//   "tracking_id": "ExampleHTTP_trackingIDAndRequestIDHeaders",
 	//   "user_agent": "",
 	//   "verb": "GET"


### PR DESCRIPTION
Ticket: https://blacklane.atlassian.net/browse/RID-90

### Fix memory leak caused by implementation of the otel http handler

The current implementation of the otel http handler is returning a new handler function for each request. This is an issue because for each request the open-telemetry `NewHandler` function that we were calling calls [this](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/67c2b13c261ee113b551f4c3c348b99fcde260f5/instrumentation/net/http/otelhttp/handler.go#L78) `createMeasure` function, that allocates memory for a "count" and a "histogram, see [here](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/67c2b13c261ee113b551f4c3c348b99fcde260f5/instrumentation/net/http/otelhttp/handler.go#L104-L105).

The result of this can be seen by the ever increasing memory usage in our services (until a pod gets restarted):

![image](https://user-images.githubusercontent.com/40300334/216128410-efb9ca75-8ed7-43ff-9268-49debe7e9cdc.png)

and can also be seen when profiling is enabled with `pprof` on a service:

<img width="769" alt="image" src="https://user-images.githubusercontent.com/40300334/216128672-d7bebe99-fcb4-4774-b171-d6a31bac9ab3.png">

The solution in this PR is to return a `http.HandlerFunc` instead that adds the information we need to the span and updates the context.
