### PR TITLE
feat: extend graceful with append functions

### DIFF
--- a/graceful/examples/main.go
+++ b/graceful/examples/main.go
@@ -52,7 +52,7 @@ func main() {
 	)
 
 	// appending task
-	g.AppendTask(graceful.NewTask(
+	if err := g.AppendTask(graceful.NewTask(
 		func(ctx context.Context) error {
 			log.Println("appended custom server - start")
 			return nil
@@ -61,7 +61,9 @@ func main() {
 			log.Println("appended custom server - stop")
 			return nil
 		},
-	))
+	)); err != nil {
+		log.Printf("could not append task: %v\n", err)
+	}
 
 	log.Printf("server running %s\n", srv.Addr)
 

--- a/graceful/examples/main.go
+++ b/graceful/examples/main.go
@@ -51,6 +51,18 @@ func main() {
 		),
 	)
 
+	// appending task
+	g.AppendTask(graceful.NewTask(
+		func(ctx context.Context) error {
+			log.Println("appended custom server - start")
+			return nil
+		},
+		func(ctx context.Context) error {
+			log.Println("appended custom server - stop")
+			return nil
+		},
+	))
+
 	log.Printf("server running %s\n", srv.Addr)
 
 	if err := g.Run(); err != nil {

--- a/graceful/graceful.go
+++ b/graceful/graceful.go
@@ -3,10 +3,11 @@ package graceful
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/go-multierror"
 	"os"
 	"os/signal"
 	"sync/atomic"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 var ErrAlreadyRunning = errors.New("already running")

--- a/graceful/graceful.go
+++ b/graceful/graceful.go
@@ -3,10 +3,11 @@ package graceful
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/go-multierror"
 	"os"
 	"os/signal"
 	"sync"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 var ErrAlreadyRunning = errors.New("already running")

--- a/graceful/graceful.go
+++ b/graceful/graceful.go
@@ -30,6 +30,24 @@ func New(opts ...Option) *Graceful {
 	}
 }
 
+func (g *Graceful) AppendTask(task Task) *Graceful {
+	g.opts.tasks = append(g.opts.tasks, task)
+
+	return g
+}
+
+func (g *Graceful) AppendBeforeStartHook(hook Hook) *Graceful {
+	g.opts.beforeStart = append(g.opts.beforeStart, hook)
+
+	return g
+}
+
+func (g *Graceful) AppendAfterStopHook(hook Hook) *Graceful {
+	g.opts.afterStop = append(g.opts.afterStop, hook)
+
+	return g
+}
+
 func (g *Graceful) beforeStart() error {
 	ctx, cancel := context.WithCancel(g.ctx)
 	defer cancel()

--- a/graceful/graceful_test.go
+++ b/graceful/graceful_test.go
@@ -136,3 +136,81 @@ func TestRun_StopOnTaskError(t *testing.T) {
 	ai32equal(t, task1Stop, 1, "unexpected calls to task-1 start")
 	ai32equal(t, task2Start, 1, "unexpected calls to task-2 stop")
 }
+
+func TestRun_Append(t *testing.T) {
+	beforeStart := new(atomic.Int32)
+	afterStop := new(atomic.Int32)
+	taskStart := new(atomic.Int32)
+	taskStop := new(atomic.Int32)
+	intervalTask := new(atomic.Int32)
+
+	g := New()
+
+	failIfError(t, g.AppendBeforeStartHook(counterHook(t, "before start 1", beforeStart)))
+	failIfError(t, g.AppendBeforeStartHook(counterHook(t, "before start 2", beforeStart)))
+	failIfError(t, g.AppendAfterStopHook(counterHook(t, "after stop", afterStop)))
+
+	failIfError(t, g.AppendTask(NewTask(
+		counterHook(t, "task start", taskStart),
+		counterHook(t, "task stop", taskStop))),
+	)
+
+	failIfError(t, g.AppendTask(NewIntervalTask(
+		300*time.Millisecond,
+		counterHook(t, "interval task", intervalTask))),
+	)
+
+	time.AfterFunc(time.Second, func() {
+		if err := g.Stop(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if err := g.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	ai32equal(t, taskStart, 1, "unexpected calls to task start")
+	ai32equal(t, taskStop, 1, "unexpected calls to task stop")
+	ai32equal(t, intervalTask, 3, "unexpected calls to interval task")
+	ai32equal(t, beforeStart, 2, "unexpected calls to before start")
+	ai32equal(t, afterStop, 1, "unexpected calls to after stop")
+}
+
+func TestRun_AppendAfterRunningError(t *testing.T) {
+	taskStart := new(atomic.Int32)
+	taskStop := new(atomic.Int32)
+
+	g := New()
+
+	var err error
+	go func() {
+		err = g.AppendTask(NewTask(
+			counterHook(t, "task start", taskStart),
+			counterHook(t, "task stop", taskStop),
+		))
+	}()
+
+	time.AfterFunc(time.Second, func() {
+		if err := g.Stop(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if err := g.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("invalid error result, got: %v, want: %v", err, ErrAlreadyRunning)
+	}
+
+	ai32equal(t, taskStart, 0, "unexpected calls to task start")
+	ai32equal(t, taskStop, 0, "unexpected calls to task stop")
+}
+
+func failIfError(t *testing.T, err error) {
+	if err != nil {
+		t.Errorf("got error: %v", err)
+	}
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -32,7 +32,7 @@ module-sets:
     modules:
       - github.com/blacklane/go-libs/errors
   graceful:
-    version: v0.0.1
+    version: v0.0.2
     modules:
       - github.com/blacklane/go-libs/graceful
 excluded-modules:

--- a/versions.yaml
+++ b/versions.yaml
@@ -32,7 +32,7 @@ module-sets:
     modules:
       - github.com/blacklane/go-libs/errors
   graceful:
-    version: v0.0.2
+    version: v0.1.0
     modules:
       - github.com/blacklane/go-libs/graceful
 excluded-modules:


### PR DESCRIPTION
## Extend graceful with append functions 

`graceful` requires that `Tasks` and `Hooks` are defined during its creation, not allowing it to be modified afterwards. 

Introducing the `Append` functions will allow a more dynamic setup.

E.g.:

```golang
g := graceful.New()

g.AppendBeforeStartHook(func(ctx context.Context) error {
	log.Println("open db connection")
	return nil
})

g.AppendTask(graceful.NewHTTPServerTask(srv))

g.AppendAfterStopHook(func(ctx context.Context) error {
	log.Println("closing db connection")
	return nil
})

if err := g.Run(); err != nil {
	log.Fatal(err)
}
```