### PR TITLE
graceful: use context with timeout when shutting down afterStop hooks

### DIFF
--- a/graceful/graceful.go
+++ b/graceful/graceful.go
@@ -76,7 +76,10 @@ func (g *Graceful) afterStop() error {
 	for _, fn := range g.opts.afterStop {
 		fn := fn
 		mg.Go(func() error {
-			return fn(g.opts.ctx)
+			stopCtx, cancel := context.WithTimeout(g.opts.ctx, g.opts.stopTimeout)
+			defer cancel()
+
+			return fn(stopCtx)
 		})
 	}
 	if err := mg.Wait(); err != nil {

--- a/versions.yaml
+++ b/versions.yaml
@@ -32,7 +32,7 @@ module-sets:
     modules:
       - github.com/blacklane/go-libs/errors
   graceful:
-    version: v0.1.0
+    version: v0.1.1
     modules:
       - github.com/blacklane/go-libs/graceful
 excluded-modules:


### PR DESCRIPTION
### Issue

During the `afterStop` hook shutdown handling, an expirable context is not passed as argument, which results in not being able to provide a timeout for the hook to shutdown. 

### How to reproduce:

The [default timeout](https://github.com/blacklane/go-libs/blob/master/graceful/options.go#L29) from graceful of 15 seconds. 

The AfterStop hook iterates 30 times, and sleep each time for 1 seconds. As it does not receive an expirable context, the hook will execute for as long as it needs.

```go
package main

import (
	"context"
	"fmt"
	"log"
	"time"

	"github.com/blacklane/go-libs/graceful"
)

func main() {
	failingTask := graceful.NewTask(func(ctx context.Context) error {
		return fmt.Errorf("generic error")
	}, func(ctx context.Context) error {
		return nil
	})

	g := graceful.New(
		graceful.WithTasks(failingTask),
		graceful.WithAfterStopHooks(func(ctx context.Context) error {
			for i := 1; i <= 30; i++ {
				select {
				case <-ctx.Done():
					log.Println("context done")
					return nil
				default:
					time.Sleep(1 * time.Second)
					log.Println("execution:", i)
				}
			}

			return fmt.Errorf("executed 30 times before returning")
		}),
	)

	now := time.Now()

	log.Println("App running")
	if err := g.Run(); err != nil {
		log.Fatalf("App stopped after %f seconds.\n%s", time.Now().Sub(now).Seconds(), err)
	}
}
```