### PR TITLE
Remove event succeeded log from EventConsumerLogger

### DIFF
--- a/logger/middleware/events.go
+++ b/logger/middleware/events.go
@@ -53,7 +53,6 @@ func EventConsumerLogger() consumer.Middleware {
 				return err
 			}
 
-			log.Info().Msgf("%s succeeded", evName)
 			return nil
 		}
 	}


### PR DESCRIPTION
# CHANGES
Removing `log.Info().Msgf("%s succeeded", evName)` from `EventConsumerLogger()` middleware since it is generating an excessive number of logs on behalf of our services.

