### PR TITLE
fix(middleware): http middlewares order

### DIFF
--- a/middleware/http.go
+++ b/middleware/http.go
@@ -16,8 +16,8 @@ import (
 func HTTP(serviceName, handlerName, path string, log logger.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			h := otel.HTTPMiddleware(serviceName, handlerName, path)(next)
-			h = logmiddleware.HTTPRequestLogger([]string{})(h)
+			h := logmiddleware.HTTPRequestLogger([]string{})(next)
+			h = otel.HTTPMiddleware(serviceName, handlerName, path)(h)
 			h = logmiddleware.HTTPAddLogger(log)(h)
 			h = HTTPTrackingID(h)
 
@@ -30,8 +30,8 @@ func HTTP(serviceName, handlerName, path string, log logger.Logger) func(http.Ha
 func HTTPWithBodyFilter(serviceName, handlerName, path string, filterKeys []string, log logger.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			h := otel.HTTPMiddleware(serviceName, handlerName, path)(next)
-			h = logmiddleware.HTTPRequestLogger([]string{})(h)
+			h := logmiddleware.HTTPRequestLogger([]string{})(next)
+			h = otel.HTTPMiddleware(serviceName, handlerName, path)(h)
 			h = logmiddleware.HTTPAddLogger(log)(h)
 			h = HTTPTrackingID(h)
 			h = logmiddleware.HTTPAddBodyFilters(filterKeys)(h)

--- a/middleware/http_example_test.go
+++ b/middleware/http_example_test.go
@@ -72,6 +72,7 @@ func ExampleHTTP() {
 	//   "path": "/foo",
 	//   "request_id": "tracking_id_ExampleHTTP",
 	//   "timestamp": "2009-11-10T23:00:00.000Z",
+	//   "trace_id": "00000000000000000000000000000000",
 	//   "tracking_id": "tracking_id_ExampleHTTP",
 	//   "user_agent": "",
 	//   "verb": "GET"
@@ -137,6 +138,7 @@ func ExampleHTTP_onlyRequestIDHeader() {
 	//   "path": "/foo",
 	//   "request_id": "ExampleHTTP_onlyRequestIDHeader",
 	//   "timestamp": "2009-11-10T23:00:00.000Z",
+	//   "trace_id": "00000000000000000000000000000000",
 	//   "tracking_id": "ExampleHTTP_onlyRequestIDHeader",
 	//   "user_agent": "",
 	//   "verb": "GET"
@@ -203,6 +205,7 @@ func ExampleHTTP_trackingIDAndRequestIDHeaders() {
 	//   "path": "/foo",
 	//   "request_id": "ExampleHTTP_trackingIDAndRequestIDHeaders",
 	//   "timestamp": "2009-11-10T23:00:00.000Z",
+	//   "trace_id": "00000000000000000000000000000000",
 	//   "tracking_id": "ExampleHTTP_trackingIDAndRequestIDHeaders",
 	//   "user_agent": "",
 	//   "verb": "GET"
@@ -236,7 +239,7 @@ func TestHTTPWithBodyFilter(t *testing.T) {
 				filterKeys:  []string{},
 				log:         logger.Logger{},
 			},
-			want: `{"level":"info","application":"TestHTTPRequestLogger","host":"example.com","ip":"192.0.2.1","params":"","path":"/with_body","request_id":"tracking_id_ExampleHTTP","tracking_id":"tracking_id_ExampleHTTP","user_agent":"","verb":"POST","http_status":200,"duration_ms":0,"body":{"hello":"world"},"timestamp":"2009-11-10T23:00:00.000Z","message":"POST /with_body"}` + "\n",
+			want: `{"level":"info","application":"TestHTTPRequestLogger","trace_id":"00000000000000000000000000000000","host":"example.com","ip":"192.0.2.1","params":"","path":"/with_body","request_id":"tracking_id_ExampleHTTP","tracking_id":"tracking_id_ExampleHTTP","user_agent":"","verb":"POST","http_status":200,"duration_ms":0,"body":{"hello":"world"},"timestamp":"2009-11-10T23:00:00.000Z","message":"POST /with_body"}` + "\n",
 		},
 	}
 	for _, tt := range tests {

--- a/versions.yaml
+++ b/versions.yaml
@@ -8,7 +8,7 @@ module-sets:
     modules:
       - github.com/blacklane/go-libs/logger
   middleware:
-    version: v0.3.8
+    version: v0.3.9
     modules:
       - github.com/blacklane/go-libs/middleware
   otel:


### PR DESCRIPTION
The OpenTelemetry middleware was executed after the logger middleware, which caused the HTTP logs to be missing trace information. This PR fixes the issue by ensuring that the OpenTelemetry middleware is executed before the logger middleware.